### PR TITLE
Changing the master/slave language

### DIFF
--- a/Imaging-1.1.7/PIL/ImageTk.py
+++ b/Imaging-1.1.7/PIL/ImageTk.py
@@ -280,12 +280,12 @@ def getimage(photo):
 def _show(image, title):
 
     class UI(Tkinter.Label):
-        def __init__(self, master, im):
+        def __init__(self, main, im):
             if im.mode == "1":
-                self.image = BitmapImage(im, foreground="white", master=master)
+                self.image = BitmapImage(im, foreground="white", main=main)
             else:
-                self.image = PhotoImage(im, master=master)
-            Tkinter.Label.__init__(self, master, image=self.image,
+                self.image = PhotoImage(im, main=main)
+            Tkinter.Label.__init__(self, main, image=self.image,
                 bg="black", bd=0)
 
     if not Tkinter._default_root:

--- a/Imaging-1.1.7/Scripts/enhancer.py
+++ b/Imaging-1.1.7/Scripts/enhancer.py
@@ -14,8 +14,8 @@ import sys
 # enhancer widget
 
 class Enhance(Frame):
-    def __init__(self, master, image, name, enhancer, lo, hi):
-        Frame.__init__(self, master)
+    def __init__(self, main, image, name, enhancer, lo, hi):
+        Frame.__init__(self, main)
 
         # set up the image
         self.tkim = ImageTk.PhotoImage(image.mode, image.size)

--- a/Imaging-1.1.7/Scripts/painter.py
+++ b/Imaging-1.1.7/Scripts/painter.py
@@ -16,8 +16,8 @@ import sys
 # painter widget
 
 class PaintCanvas(Canvas):
-    def __init__(self, master, image):
-        Canvas.__init__(self, master, width=image.size[0], height=image.size[1])
+    def __init__(self, main, image):
+        Canvas.__init__(self, main, width=image.size[0], height=image.size[1])
 
         # fill the canvas
         self.tile = {}

--- a/Imaging-1.1.7/Scripts/player.py
+++ b/Imaging-1.1.7/Scripts/player.py
@@ -35,7 +35,7 @@ class AppletDisplay:
 
 class UI(Label):
 
-    def __init__(self, master, im):
+    def __init__(self, main, im):
         if type(im) == type([]):
             # list of images
             self.im = im[1:]
@@ -53,7 +53,7 @@ class UI(Label):
         global animation_display
         animation_display = AppletDisplay(self)
 
-        Label.__init__(self, master, image=self.image, bg="black", bd=0)
+        Label.__init__(self, main, image=self.image, bg="black", bd=0)
 
         self.update()
 

--- a/Imaging-1.1.7/Scripts/thresholder.py
+++ b/Imaging-1.1.7/Scripts/thresholder.py
@@ -14,8 +14,8 @@ import sys
 # an image viewer
 
 class UI(Frame):
-    def __init__(self, master, im, value = 128):
-        Frame.__init__(self, master)
+    def __init__(self, main, im, value = 128):
+        Frame.__init__(self, main)
 
         self.image = im
         self.value = value

--- a/Imaging-1.1.7/Scripts/viewer.py
+++ b/Imaging-1.1.7/Scripts/viewer.py
@@ -11,17 +11,17 @@ from PIL import Image, ImageTk
 
 class UI(Label):
 
-    def __init__(self, master, im):
+    def __init__(self, main, im):
 
         if im.mode == "1":
             # bitmap image
             self.image = ImageTk.BitmapImage(im, foreground="white")
-            Label.__init__(self, master, image=self.image, bg="black", bd=0)
+            Label.__init__(self, main, image=self.image, bg="black", bd=0)
 
         else:
             # photo image
             self.image = ImageTk.PhotoImage(im)
-            Label.__init__(self, master, image=self.image, bd=0)
+            Label.__init__(self, main, image=self.image, bd=0)
 
 #
 # script interface

--- a/Imaging-1.1.7/build/lib.macosx-10.6-intel-2.7/ImageTk.py
+++ b/Imaging-1.1.7/build/lib.macosx-10.6-intel-2.7/ImageTk.py
@@ -280,12 +280,12 @@ def getimage(photo):
 def _show(image, title):
 
     class UI(Tkinter.Label):
-        def __init__(self, master, im):
+        def __init__(self, main, im):
             if im.mode == "1":
-                self.image = BitmapImage(im, foreground="white", master=master)
+                self.image = BitmapImage(im, foreground="white", main=main)
             else:
-                self.image = PhotoImage(im, master=master)
-            Tkinter.Label.__init__(self, master, image=self.image,
+                self.image = PhotoImage(im, main=main)
+            Tkinter.Label.__init__(self, main, image=self.image,
                 bg="black", bd=0)
 
     if not Tkinter._default_root:

--- a/Imaging-1.1.7/doctest.py
+++ b/Imaging-1.1.7/doctest.py
@@ -141,7 +141,7 @@ def _test():
     verbose = "-v" in sys.argv
     for mod in modules:
         doctest.testmod(mod, verbose=verbose, report=0)
-    doctest.master.summarize()
+    doctest.main.summarize()
 
 if __name__ == "__main__":
     _test()
@@ -150,7 +150,7 @@ IOW, it just runs testmod on all the pkg modules.  testmod remembers the
 names and outcomes (# of failures, # of tries) for each item it's seen, and
 passing "report=0" prevents it from printing a summary in verbose mode.
 Instead, the summary is delayed until all modules have been tested, and
-then "doctest.master.summarize()" forces the summary at the end.
+then "doctest.main.summarize()" forces the summary at the end.
 
 So this is very nice in practice:  each module can be tested individually
 with almost no work beyond writing up docstring examples, and collections
@@ -180,10 +180,10 @@ often.  You may want other policies.
 
 testmod() actually creates a local instance of class doctest.Tester, runs
 appropriate methods of that class, and merges the results into global
-Tester instance doctest.master.
+Tester instance doctest.main.
 
 You can create your own instances of doctest.Tester, and so build your own
-policies, or even run methods of doctest.master directly.  See
+policies, or even run methods of doctest.main directly.  See
 doctest.Tester.__doc__ for details.
 
 
@@ -976,7 +976,7 @@ see its docs for details.
             return 0, 0
         return self.rundoc(target, name)
 
-master = None
+main = None
 
 def testmod(m, name=None, globs=None, verbose=None, isprivate=None,
                report=1):
@@ -1015,14 +1015,14 @@ def testmod(m, name=None, globs=None, verbose=None, isprivate=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
 
-    global master
+    global main
 
     if type(m) is not _ModuleType:
         raise TypeError("testmod: module required; " + `m`)
@@ -1044,10 +1044,10 @@ def testmod(m, name=None, globs=None, verbose=None, isprivate=None,
             tries = tries + t
     if report:
         tester.summarize()
-    if master is None:
-        master = tester
+    if main is None:
+        main = tester
     else:
-        master.merge(tester)
+        main.merge(tester)
     return failures, tries
 
 class _TestClass:

--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -204,8 +204,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -229,11 +229,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -264,7 +264,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -299,15 +299,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -443,15 +443,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/boto/emr/step.py
+++ b/boto/emr/step.py
@@ -124,7 +124,7 @@ class StreamingStep(Step):
         :type output: str
         :param output: The output uri
         :type jar: str
-        :param jar: The hadoop streaming jar. This can be either a local path on the master node, or an s3:// URI.
+        :param jar: The hadoop streaming jar. This can be either a local path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/boto/pyami/bootstrap.py
+++ b/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -143,8 +143,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -171,8 +171,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -221,8 +221,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-ex
                        * sqlserver-web
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -239,8 +239,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -368,8 +368,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -389,8 +389,8 @@ class RDSConnection(AWSQueryConnection):
                   'Engine': engine,
                   'EngineVersion': engine_version,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -483,7 +483,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -505,8 +505,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -564,8 +564,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/boto/rds/dbinstance.py
+++ b/boto/rds/dbinstance.py
@@ -41,7 +41,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_group: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -75,7 +75,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_group = None
         self.security_group = None
         self.availability_zone = None
@@ -121,8 +121,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -212,7 +212,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -230,8 +230,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -278,7 +278,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/boto/rds/dbsnapshot.py
+++ b/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     """
     
     def __init__(self, connection=None, id=None):
@@ -49,7 +49,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -77,8 +77,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.